### PR TITLE
fix error when lazy-loading MappedCollection relationships

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nplus1loader',
-    version='1.0.2b1',
+    version='1.0.2b2',
     author='Mark Vartanyan',
     author_email='kolypto@gmail.com',
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm.collections import attribute_mapped_collection
 
 
 Base = declarative_base()
@@ -17,6 +18,7 @@ class Number(Base):
     no = Column(String(100), nullable=True)
 
     fruits = relationship(lambda: Fruit, back_populates='number')
+    fruits_map = relationship(lambda: Fruit, collection_class=attribute_mapped_collection('en'))
 
 
 class Fruit(Base):


### PR DESCRIPTION
When you try to apply nplus1loader to some mapped_collection(),
you get an exception on attribute access:

    AttributeError: 'str' object has no attribute '...'

That happens because SQLAlchemy always populates collections
from a list, even if the collection is dict-like.

But, nplus1loader gives it a dict instead of list.

Then SQLAlchemy tries to walk across it using `for ... in` loop,
and with `dict` that means that it walks over keys (while really
it should walk over ORM instances).

So it tries to rach some attribute of the string key,
and fails with the exception listed above.

The solution is hacky: discard dict keys, and feed only values
(the list of ORM instances) back to the SQLAlchemy.

That is slightly inoptimal (since we're poplating each
MappedCollection exaclty twice, and the first copy is thrown away),
but at least, it works.